### PR TITLE
rmffile = ./... instead of rmffile = /...

### DIFF
--- a/NICER/data/NICER_data_reduction.ipynb
+++ b/NICER/data/NICER_data_reduction.ipynb
@@ -189,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": null,
    "id": "4195f3b2",
    "metadata": {
     "scrolled": true
@@ -248,8 +248,8 @@
     "#Run nicerl3-lc to generate a lightcurve (and background lightcurve) in the 1 to 5 and 3 to 7 keV energy bands\n",
     "if mergeobs==0:\n",
     "    for i in obsids:\n",
-    "        os.system(f'nicerl3-lc {i}  mkfile=./{i}/auxil/ni{i}.mkf clfile=./{i}/xti/event_cl/ni{i}_0mpu7_cl.evt skyarffile=./{i}/xti/event_cl/ni{i}mpu7_sksco.arf rmffile=/{i}/xti/event_cl/ni{i}mpu7sco.rmf 100-500 300.0 suffix=1to5 bkgmodeltype=scorpeon clobber=YES')\n",
-    "        os.system(f'nicerl3-lc {i}  mkfile=./{i}/auxil/ni{i}.mkf clfile=./{i}/xti/event_cl/ni{i}_0mpu7_cl.evt skyarffile=./{i}/xti/event_cl/ni{i}mpu7_sksco.arf rmffile=/{i}/xti/event_cl/ni{i}mpu7sco.rmf 300-700 300.0 suffix=3to7 bkgmodeltype=scorpeon clobber=YES')\n",
+    "        os.system(f'nicerl3-lc {i}  mkfile=./{i}/auxil/ni{i}.mkf clfile=./{i}/xti/event_cl/ni{i}_0mpu7_cl.evt skyarffile=./{i}/xti/event_cl/ni{i}mpu7_sksco.arf rmffile=./{i}/xti/event_cl/ni{i}mpu7sco.rmf 100-500 300.0 suffix=1to5 bkgmodeltype=scorpeon clobber=YES')\n",
+    "        os.system(f'nicerl3-lc {i}  mkfile=./{i}/auxil/ni{i}.mkf clfile=./{i}/xti/event_cl/ni{i}_0mpu7_cl.evt skyarffile=./{i}/xti/event_cl/ni{i}mpu7_sksco.arf rmffile=./{i}/xti/event_cl/ni{i}mpu7sco.rmf 300-700 300.0 suffix=3to7 bkgmodeltype=scorpeon clobber=YES')\n",
     "elif mergeobs==1:\n",
     "    os.system(f'nicerl3-lc {outdir} ufafile=./{outdir}/ni{outdir}_0mpu7_ufa.evt mkfile=./{outdir}/ni{outdir}.mkf clfile=./{outdir}/ni{outdir}_0mpu7_cl.evt skyarffile=./{outdir}/ni{outdir}mpu7_sksco.arf rmffile=./{outdir}/ni{outdir}mpu7sco.rmf 100-500 300.0 bkgmodeltype=scorpeon suffix=1to5 clobber=YES')\n",
     "    os.system(f'nicerl3-lc {outdir} ufafile=./{outdir}/ni{outdir}_0mpu7_ufa.evt mkfile=./{outdir}/ni{outdir}.mkf clfile=./{outdir}/ni{outdir}_0mpu7_cl.evt skyarffile=./{outdir}/ni{outdir}mpu7_sksco.arf rmffile=./{outdir}/ni{outdir}mpu7sco.rmf 300-700 300.0 bkgmodeltype=scorpeon suffix=3to7 clobber=YES')\n",


### PR DESCRIPTION
the rmffile parameter was using an absolute path "/" rather than a path relative to the CWD "./" which caused the notebook to fail.  Changed rmffile to a relative path